### PR TITLE
Initialize instrument banks

### DIFF
--- a/Driver/SoundSystem.asm
+++ b/Driver/SoundSystem.asm
@@ -412,18 +412,18 @@ SoundSystem_Init::
 	ld	e,4
 	IF (SOUNDSYSTEM_LARGE_ROM)
 .instbankloop:
-	ld  a,LOW(BANK(Music_InstrumentEnd))
-	ld  [hl+],a
-	ld  a,HIGH(BANK(Music_InstrumentEnd))
-	ld  [hl+],a
-	dec e
-	jr  nz,.instbankloop
+	ld	a,LOW(BANK(Music_InstrumentEnd))
+	ld	[hl+],a
+	ld	a,HIGH(BANK(Music_InstrumentEnd))
+	ld	[hl+],a
+	dec	e
+	jr	nz,.instbankloop
 	ELSE
-	ld  a,BANK(Music_InstrumentEnd)
+	ld	a,BANK(Music_InstrumentEnd)
 .instbankloop:
-	ld  [hl+],a
-	dec e
-	jr  nz,.instbankloop
+	ld	[hl+],a
+	dec	e
+	jr	nz,.instbankloop
 	ENDC
 
 	; set all channel volumes to 8

--- a/Driver/SoundSystem.asm
+++ b/Driver/SoundSystem.asm
@@ -407,6 +407,25 @@ SoundSystem_Init::
 	dec	e
 	jr	nz,.instptrloop
 
+	; set all channel banks to be the bank with the stop instrument
+	ld	hl,wMusicSFXInstBank1
+	ld	e,4
+	IF (SOUNDSYSTEM_LARGE_ROM)
+.instbankloop:
+	ld  a,LOW(BANK(Music_InstrumentEnd))
+	ld  [hl+],a
+	ld  a,HIGH(BANK(Music_InstrumentEnd))
+	ld  [hl+],a
+	dec e
+	jr  nz,.instbankloop
+	ELSE
+	ld  a,BANK(Music_InstrumentEnd)
+.instbankloop:
+	ld  [hl+],a
+	dec e
+	jr  nz,.instbankloop
+	ENDC
+
 	; set all channel volumes to 8
 	ld	a,$80
 	ld	hl,wChannelVol1


### PR DESCRIPTION
The instrument banks are left uninitialized, although the instrument
themselves are initialized to point to dummy instruments.

If the sound system is run for 256 frames before any song or
sound effect is played, BGB raises an "accessing uninitialized WRAM"
exception when attempting to switch to the instrument bank.

This diff initializes the banks to point to the appropriate one for the
dummy instrument (i.e. the sound system bank).

This still triggers an MBC1 write exception in BGB if the engine is in
bank 0, but it should be harmless.