### PR TITLE
Fix incorrect silencing of channel 4 in Music_Pause

### DIFF
--- a/Driver/SoundSystem.asm
+++ b/Driver/SoundSystem.asm
@@ -1127,7 +1127,7 @@ Music_Pause::
 	;-------------------------------
 	; channel 4
 	bit	SFXLOCKB_CHANNEL4,b	; is channel 4 playing music?
-	ret	nz			; no, exit
+	ret	z			; no, exit
 	; clear the channel 4 registers
 	xor	a
 	ldh	[rAUD4ENV],a


### PR DESCRIPTION
If there was no sound effect playing in channel 4 when pausing the music, the channel would be silenced, but if there was, it would be left alone. This is the inverse of what should happen.